### PR TITLE
Fix database load error

### DIFF
--- a/vb_django/db_setup.py
+++ b/vb_django/db_setup.py
@@ -9,7 +9,7 @@ logger.setLevel(logging.INFO)
 
 def load_pipelines(purge: bool = False):
     pl = pipelines
-    if purge:
+    if purge and not PipelineInstance.DoesNotExist:
         logger.info("Purging existing pipeline-instance data")
         PipelineInstance.objects.all().delete()
     logger.info("Setting up and loading pipeline instance hyper-parameters and metadata")


### PR DESCRIPTION
### Issue
When the db.sqlite3 file is empty, line 14 of the db_setup.py file is attempting to purge the database and is returning an exception because the tables do not exist. Bug as introduced at this commit: https://github.com/quanted/vb_django/commit/bf8d820bb16d4625fea18ac6b69d8eced47ec8ab#diff-5f0b00990e958643a1c9e0420db21f97ffd89c2d12daa23c2d466b08c3a23ae6

```
/usr/local/bin/python3.8 /Users/brandonmain/EPA/Virtual-Beach/vb_django/manage.py runserver 8000
Starting vb django applications
DEBUG: True
ALLOWED_HOSTS: ['*']
IN_DOCKER: false
DATABASE: /Users/brandonmain/EPA/Virtual-Beach/vb_django/db.sqlite3
Starting vb django applications
DEBUG: True
ALLOWED_HOSTS: ['*']
IN_DOCKER: false
DATABASE: /Users/brandonmain/EPA/Virtual-Beach/vb_django/db.sqlite3
Watching for file changes with StatReloader
Performing system checks...

Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/sqlite3/base.py", line 396, in execute
    return Database.Cursor.execute(self, query, params)
sqlite3.OperationalError: no such table: vb_django_pipelineinstance

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/utils/autoreload.py", line 53, in wrapper
    fn(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/commands/runserver.py", line 117, in inner_run
    self.check(display_num_errors=True)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 392, in check
    all_issues = self._run_checks(
  File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 382, in _run_checks
    return checks.run_checks(**kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/core/checks/registry.py", line 72, in run_checks
    new_errors = check(app_configs=app_configs)
  File "/usr/local/lib/python3.8/site-packages/django/core/checks/urls.py", line 13, in check_url_config
    return check_resolver(resolver)
  File "/usr/local/lib/python3.8/site-packages/django/core/checks/urls.py", line 23, in check_resolver
    return check_method()
  File "/usr/local/lib/python3.8/site-packages/django/urls/resolvers.py", line 407, in check
    for pattern in self.url_patterns:
  File "/usr/local/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/usr/local/lib/python3.8/site-packages/django/urls/resolvers.py", line 588, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/usr/local/lib/python3.8/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/usr/local/lib/python3.8/site-packages/django/urls/resolvers.py", line 581, in urlconf_module
    return import_module(self.urlconf_name)
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/brandonmain/EPA/Virtual-Beach/vb_django/vb_django/urls.py", line 73, in <module>
    load_pipelines(purge=True)
  File "/Users/brandonmain/EPA/Virtual-Beach/vb_django/vb_django/db_setup.py", line 14, in load_pipelines
    PipelineInstance.objects.all().delete()
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 721, in delete
    collector.collect(del_query)
  File "/usr/local/lib/python3.8/site-packages/django/db/models/deletion.py", line 196, in collect
    new_objs = self.add(objs, source, nullable,
  File "/usr/local/lib/python3.8/site-packages/django/db/models/deletion.py", line 89, in add
    if not objs:
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 280, in __bool__
    self._fetch_all()
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 1261, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 57, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/usr/local/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1144, in execute_sql
    cursor.execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 100, in execute
    return super().execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 68, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 77, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/sqlite3/base.py", line 396, in execute
    return Database.Cursor.execute(self, query, params)
django.db.utils.OperationalError: no such table: vb_django_pipelineinstance

Process finished with exit code 0
```

### Fix
Proposed fix is to do a small check if the PipelineInstance exists before trying to purge.
